### PR TITLE
140MB for sblive

### DIFF
--- a/systemback/systemback.cpp
+++ b/systemback/systemback.cpp
@@ -2639,7 +2639,7 @@ void systemback::livewrite()
         }
         else
         {
-            if(! (sb::mkpart(ldev, 1048576, 104857600) && sb::mkpart(ldev)) || intrrpt) return err(338);
+            if(! (sb::mkpart(ldev, 1048576, 144857600) && sb::mkpart(ldev)) || intrrpt) return err(338);
             sb::delay(100);
             if(sb::exec("mkfs.ext2 -FL SBROOT " % ldev % (ismmc ? "p" : nullptr) % '2') || intrrpt) return err(338);
             lrdir = "sbroot";


### PR DESCRIPTION
related to the issue https://github.com/fconidi/systemback-install_pack-1.9.4/issues/2   new size is set to 140MB